### PR TITLE
fix the AUR and add another Arch Linux method

### DIFF
--- a/doc/Quickstart.md
+++ b/doc/Quickstart.md
@@ -48,7 +48,8 @@ For reasons of performance, IQ-TREE is a command-line program, i.e., IQ-TREE nee
 Ready made IQ-TREE packages are available for the following distributions/repositories (command to install iqtree):
 
 * [Debian Linux](https://packages.debian.org/unstable/science/iqtree): `sudo apt-get install iqtree`
-* [Arch Linux (AUR)](https://aur.archlinux.org/packages/iqtree-latest/)
+* [Arch Linux (AUR)](https://aur.archlinux.org/packages/iqtree/) `yay -S iqtree` or `paru -S iqtree`
+* [Arch Linux (BioArchLinux)](https://github.com/BioArchLinux/Packages) `sudo pacman -S iqtree` after add BioArchLinux repository
 * [Anaconda](https://anaconda.org/bioconda/iqtree): `conda install -c bioconda iqtree`
 * [Homebrew](https://github.com/brewsci/homebrew-bio/blob/master/Formula/iqtree.rb): `brew install brewsci/bio/iqtree2`
 * [FreeBSD](https://www.freshports.org/biology/iqtree/): `pkg install iqtree`


### PR DESCRIPTION
fix the AUR and add another way to install iqtree on Arch Linux