### PR TITLE
Update GitHub repository link in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
                 <h4>Software</h4>
                 <p>
                     <a href="{{"/release/" | prepend: site.baseurl }}">Release notes</a><br>
-                    <a href="https://github.com/iqtree/iqtree2">GitHub repository</a><br>
+                    <a href="https://github.com/iqtree/iqtree3">GitHub repository</a><br>
                     <a href="{{"/about/" | prepend: site.baseurl }}">Development team</a><br>
                 </p>
             </div>


### PR DESCRIPTION
change to 3 instead of 2

I see in some documentation (e.g., [here](https://github.com/iqtree/iqtree.github.io/blob/master/release.html)) that `{{ post.version }}` seems to be used to dynamically give the appropriate version number. I am unsure if that can be used or would be appropriate here but it might save having to manually update the versions.